### PR TITLE
[docs] Fix missing doc link on PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,4 +62,4 @@ If you set ``p``, ``li`` and others into `budoux_targets``, this may not work co
 Example
 =======
 
-See `doc <doc/>`_ (written by Japanese).
+See `doc <https://attakei-lab.github.io/sphinxcontrib-budoux/>`__ (written by Japanese).


### PR DESCRIPTION
素晴らしいライブラリをありがとうございます。

PyPIにて「See doc (written by Japanese).」のリンクが
https://pypi.org/project/sphinxcontrib-budoux/doc/
となって404 Not Foundとなっていました。

リポジトリのURLに設定されているドキュメントのURLに変更することで、
PyPIからもドキュメントに遷移できるようになると思います